### PR TITLE
remove memset connectionInfo

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -822,7 +822,6 @@ int main(int argc, char** argv)
 
     //-------------------------------------
     // setup a pool connection.
-    memset(&global::connectionInfo, 0, sizeof(ConnectionInfo));
     // get url
     csetting = cf.getSetting("Connection", "Url");
     if (csetting) global::connectionInfo.rpc_url = csetting->AsString;


### PR DESCRIPTION
Should never memset std::string, fix segmentation fault bug